### PR TITLE
Replaced buggy HTML5 Audio with howler.js

### DIFF
--- a/InteractSound/client/html/index.html
+++ b/InteractSound/client/html/index.html
@@ -2,6 +2,7 @@
     <head>
         <!-- Need to include jQuery! -->
         <script src="nui://game/ui/jquery.js" type="text/javascript"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.1.1/howler.min.js" type="text/javascript"></script>
         <script>
             var audioPlayer = null;
             // Listen for NUI Messages.
@@ -13,8 +14,8 @@
                     audioPlayer.pause();
                   }
 
-                  audioPlayer = new Audio("./sounds/" + event.data.transactionFile + ".ogg");
-                  audioPlayer.volume = event.data.transactionVolume;
+                  audioPlayer = new Howl({src: ["./sounds/" + event.data.transactionFile + ".ogg"]});
+                  audioPlayer.volume(event.data.transactionVolume);
                   audioPlayer.play();
 
                 }


### PR DESCRIPTION
During the development of another FiveM resource we noticed that the old implementation of InteractSound was acting strange and both cutting off, repeating, or refusing to play our audio files. It was difficult to predict when and if this would happen, but for some audio files this behavior was the norm rather than the exception.

By replacing the buggy HTML5 Audio implementation with howler.js (which defaults to Web Audio API and falls back to HTML5 Audio) all of our issues disappeared, so I figured I'd submit a pull request so that other can benefit from these changes too. 

Note that I have not updated the zip file in the repository.